### PR TITLE
Fixed AoE indicators broken to signature change in SetSpellRangeScale

### DIFF
--- a/BubbleTweaks/AoeIndicators.cs
+++ b/BubbleTweaks/AoeIndicators.cs
@@ -90,7 +90,7 @@ namespace BubbleTweaks {
                 var material = markerObj.GetComponentInChildren<MeshRenderer>().material;
                 material.color = GetColor(false, entityData);
                 var decal = markerObj.GetComponentInChildren<GUIDecal>();
-                decal.SetSpellRangeScale(entityData.Blueprint.Size.Meters * 2 + 0.25f, 0);
+                decal.SetSpellRangeScale(entityData.Blueprint.Size.Meters * 2 + 0.25f, 0, 0);
                 decal.SetRangeColor(false, true, 1);
 
                 markers.Add(entityData, new AreaMarker {


### PR DESCRIPTION
Best of AoE indicators for the best of Bubbles
![222](https://user-images.githubusercontent.com/126824833/234680623-06c7dd3d-0196-4b09-8cfd-0b89bfe2b923.jpg)
